### PR TITLE
feat: converting error handing to anyhow

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -60,6 +60,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anyhow"
+version = "1.0.89"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86fdf8605db99b54d3cd748a44c6d04df638eb5dafb219b135d0149bd0db01f6"
+
+[[package]]
 name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -355,6 +361,7 @@ dependencies = [
 name = "is_affected"
 version = "0.4.2"
 dependencies = [
+ "anyhow",
  "clap",
  "git2",
  "log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,9 @@ git2 = { version = "0.19.0", default-features = false, features=[] }
 # For checking affected paths.
 regex = "1.9.6"
 
+# For error handling.
+anyhow = "1.0.89"
+
 
 [dev-dependencies]
 # For parameterized testing.

--- a/end-to-end-tests/features/steps/assertions.py
+++ b/end-to-end-tests/features/steps/assertions.py
@@ -24,6 +24,12 @@ def assert_error_equals(result, error):
         f"Error          = {error.encode()}.\n"
 
 
+def assert_error_contains(result, error):
+    assert error in result.stderr, "Expected standard error to contain the error.\n" + \
+        f"Standard error = {result.stderr.encode()}.\n" + \
+        f"Error          = {error.encode()}.\n"
+
+
 def assert_error_matches_regex(result, regex):
     assert regex.match(result.stderr) is not None, f"Expected standard errors to match the regex.\n" + \
         f"Standard error = {result.stderr.encode()}.\n" + \

--- a/end-to-end-tests/features/steps/then.py
+++ b/end-to-end-tests/features/steps/then.py
@@ -39,13 +39,13 @@ def assert_is_not_affected(context):
 @then('their is a could not find commit hash "{commit_hash}" error.')
 def assert_could_not_find_commit_hash_error(context, commit_hash):
     # Given
-    could_not_find_commit_hash_error = f" ERROR is_affected::commits > Can not find a commit with the hash '{commit_hash}'.\n"  # fmt: off
+    could_not_find_commit_hash_error = f"Can not find a commit with the hash '{commit_hash}'.\n"  # fmt: off
 
     # When/Then
     result = assert_is_not_affected(context)
 
     # Then
-    assert_error_equals(result, could_not_find_commit_hash_error)
+    assert_error_contains(result, could_not_find_commit_hash_error)
 
 
 @then(
@@ -53,13 +53,13 @@ def assert_could_not_find_commit_hash_error(context, commit_hash):
 def assert_could_not_find_shortened_commit_hash_error(
         context, shortened_commit_hash):
     # Given
-    could_not_find_shortened_commit_hash_error = f" ERROR is_affected::commits > No commit hashes start with the provided short commit hash \"{shortened_commit_hash}\".\n"  # fmt: off
+    could_not_find_shortened_commit_hash_error = f"No commit hashes start with the provided short commit hash \"{shortened_commit_hash}\".\n"  # fmt: off
 
     # When/Then
     result = assert_is_not_affected(context)
 
     # Then
-    assert_error_equals(result, could_not_find_shortened_commit_hash_error)
+    assert_error_contains(result, could_not_find_shortened_commit_hash_error)
 
 
 @then(
@@ -67,7 +67,7 @@ def assert_could_not_find_shortened_commit_hash_error(
 def assert_ambiguous_shortened_commit_hash_error(
         context, shortened_commit_hash):
     # Given
-    ambiguous_shortened_commit_hash_error = re.compile(f"^ ERROR is_affected::commits > Ambiguous short commit hash, the commit hashes [[]({shortened_commit_hash}[a-f0-9]*(, )?)*[]] all start with the provided short commit hash \"{shortened_commit_hash}\".\n$")  # fmt: off
+    ambiguous_shortened_commit_hash_error = re.compile(f"^ ERROR is_affected > Ambiguous short commit hash, the commit hashes [[]({shortened_commit_hash}[a-f0-9]*(, )?)*[]] all start with the provided short commit hash \"{shortened_commit_hash}\".\n$")  # fmt: off
 
     # When/Then
     result = assert_is_not_affected(context)
@@ -79,13 +79,13 @@ def assert_ambiguous_shortened_commit_hash_error(
 @then('their is a could not find reference "{reference}" error.')
 def assert_could_not_find_reference_error(context, reference):
     # Given
-    could_not_find_reference_error = f" ERROR is_affected::commits > Could not find a reference with the name \"{reference}\".\n"  # fmt: off
+    could_not_find_reference_error = f"Could not find a reference with the name \"{reference}\".\n"  # fmt: off
 
     # When/Then
     result = assert_is_not_affected(context)
 
     # Then
-    assert_error_equals(result, could_not_find_reference_error)
+    assert_error_contains(result, could_not_find_reference_error)
 
 
 @then('their is a missing from argument error.')


### PR DESCRIPTION
Refactored end to end test error assertions to contains, because we now get the
full chain of error with context. So it is not as easy to assert on the entire
error message.