### PR TITLE
ci: removing Alpine Renovate version updating

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -23,20 +23,6 @@
     {
       "customType": "regex",
       "fileMatch": [
-        "^Earthfile$"
-      ],
-      "matchStrings": [
-        "# renovate: datasource=repology packageName=alpine_(?<currentValue>\\d+[._]\\d+)"
-      ],
-      "currentValueTemplate": "{{{ replace '_' '.' currentValue }}}",
-      "datasourceTemplate": "docker",
-      "depNameTemplate": "alpine",
-      "versioningTemplate": "regex:^(?<major>\\d+)[._](?<minor>\\d+)$",
-      "autoReplaceStringTemplate": "# renovate: datasource=repology packageName=alpine_{{{newMajor}}}_{{{newMinor}}}"
-    },
-    {
-      "customType": "regex",
-      "fileMatch": [
         "^[.]github/workflows/"
       ],
       "matchStrings": [


### PR DESCRIPTION
Removing the custom manager for updating all the repology lines with the Alpine image's version, as we changed to using the Rust Alpine image.